### PR TITLE
Fix closing tags in splash pricing table

### DIFF
--- a/plans/index.html
+++ b/plans/index.html
@@ -248,17 +248,17 @@ $(document).ready(function(){
                   </tr>
                   <tr>
                     <td>1,000</td>
-                    <td><span class="splash-small">$20</splash></td>
+                    <td><span class="splash-small">$20</span></td>
                     <td>30 days</td>
                   </tr>
                   <tr>
                     <td>5,000</td>
-                    <td><span class="splash-med">$35</splash></td>
+                    <td><span class="splash-med">$35</span></td>
                     <td>30 days</td>
                   </tr>
                   <tr>
                     <td>50,000</td>
-                    <td><span class="splash-large">$70</splash></td>
+                    <td><span class="splash-large">$70</span></td>
                     <td>30 days</td>
                   </tr>
               </table>


### PR DESCRIPTION
## Summary
- fix invalid `</splash>` closing tags in Plans page

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68482be35de08333841b8f6d0c4cac02